### PR TITLE
Add button reset and disable

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -142,6 +142,7 @@ const checkForm = () => {
   if (dateCheck && durationCheck && travelersCheck) {
     formSubmitButton.disabled = false;
     getEstimateButton.disabled = false;
+    getEstimateButton.innerText = 'Get Estimate';
   } else {
     formSubmitButton.disabled = true;
     getEstimateButton.disabled = true;
@@ -162,7 +163,7 @@ const getTripEstimate = () => {
   })
 
   getEstimateButton.innerText = `$${trip.calculateTripCost(destinationRepo)}`
-
+  getEstimateButton.disabled = true;
 }
 
 const checkLogin = () => {


### PR DESCRIPTION
# Description
Changes functionality of the get estimate button of the book trip form.

- On click it will disable and present cost
- When user changes date/duration/traveler amount the button reset to original text (enabling a new estimate)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [x] open index.html / npm start
- [ ] console.log()
- [ ] dev tools
- [ ] npm test
- [x] other

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
